### PR TITLE
Replaced "burnbright/silverstripe-shop" dependency with "silvershop/core"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	"require" : {
 		"silverstripe/cms": "~3.1",
 		"silverstripe/framework": "~3.1",
-		"burnbright/silverstripe-shop": "~1.0"
+		"silvershop/core": "~1.0"
 	},
 	"extra" : {
 		"installer-name": "shop_googleanalytics"


### PR DESCRIPTION
This is required to keep from having two instances of the SilverShop add-on.
